### PR TITLE
Fix updating JWKS service accounts

### DIFF
--- a/internal/provider/service_account_resource.go
+++ b/internal/provider/service_account_resource.go
@@ -258,9 +258,13 @@ func (r *serviceAccountResource) Update(ctx context.Context, req resource.Update
 			return
 		}
 		serviceAccount.JwksURI = plan.JwksURI.ValueString()
-		serviceAccount.IssuerURL = plan.IssuerURL.ValueString()
+		if state.IssuerURL.ValueString() != plan.IssuerURL.ValueString() {
+			serviceAccount.IssuerURL = plan.IssuerURL.ValueString()
+		}
 		serviceAccount.Audience = plan.Audience.ValueString()
-		serviceAccount.Subject = plan.Subject.ValueString()
+		if state.Subject.ValueString() != plan.Subject.ValueString() {
+			serviceAccount.Subject = plan.Subject.ValueString()
+		}
 		serviceAccount.AuthenticationType = "rsaKeyFederated"
 
 		apps := []string{}


### PR DESCRIPTION
If we try to update a JWKS service account with the same Issuer/Subject, we get an error that the Issuer/Audience must be unique across all service accounts. I think this is a bug in TLSPC (Issuer/Subject are still unique if we're acting on the same service account).

Workaround this by only providing the Issuer/Subject to the update payload if they have changed.