### PR TITLE
Client: add the user-agent header

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -74,7 +74,7 @@ func (p *tlspcProvider) Configure(ctx context.Context, req provider.ConfigureReq
 		endpoint = config.Endpoint.ValueString()
 	}
 
-	client, _ := tlspc.NewClient(apikey, endpoint)
+	client, _ := tlspc.NewClient(apikey, endpoint, p.version)
 
 	resp.DataSourceData = client
 	resp.ResourceData = client

--- a/internal/tlspc/tlspc.go
+++ b/internal/tlspc/tlspc.go
@@ -17,9 +17,10 @@ const DefaultEndpoint = "https://api.venafi.cloud"
 type Client struct {
 	apikey   string
 	endpoint string
+	version  string
 }
 
-func NewClient(apikey, endpoint string) (*Client, error) {
+func NewClient(apikey, endpoint, version string) (*Client, error) {
 	if endpoint == "" {
 		endpoint = DefaultEndpoint
 	}
@@ -27,6 +28,7 @@ func NewClient(apikey, endpoint string) (*Client, error) {
 	return &Client{
 		apikey:   apikey,
 		endpoint: endpoint,
+		version:  version,
 	}, nil
 }
 
@@ -37,6 +39,7 @@ func (c *Client) doRequest(method, path string, body []byte) (*http.Response, er
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("tppl-api-key", c.apikey)
+	req.Header.Set("User-Agent", "terraform-provider-tlspc/"+c.version)
 
 	client := http.Client{}
 	return client.Do(req)


### PR DESCRIPTION
Peter was mitmproxy-ing terraform-provider-tlspc with me and we found that the provider currently uses the default user-agent:

```http
User-Agent: Go-http-client/2.0
```

It would be great to give a more specific user-agent.

**Why?** Will be super useful to use Datadog logs to show how many users of terraform-provider-tlspc there are over time, and also useful when debugging issues with Datadog.

**Note:** I haven't tested this manually, and haven't created a test either.

WDYT?