### PR TITLE
Replace deprecated exportloopref linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,7 +9,7 @@ linters:
   enable:
     - durationcheck
     - errcheck
-    - exportloopref
+    - copyloopvar
     - forcetypeassert
     - godot
     - gofmt


### PR DESCRIPTION
This linter is deprecated as of go 1.22, as we're on 1.22.7, we can safely replace this linter.

https://github.com/golangci/golangci-lint/pull/4916