### PR TITLE
Add CyberArk's Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,66 @@
+# CyberArk Community Code of Conduct
+
+CyberArk is a leader in Privileged Access Management, thanks to its customers and community. We listen to our community and wish to provide additional relevant tools.  We believe that our mission is best served in an environment that is friendly, safe, and accepting; free from intimidation or harassment.
+Towards this end, CyberArk’s developers have created this Community Code of Conduct for the CyberArk open source community.  Our Code of Conduct sets the standard for how developers, and community members can work together in a respectful and collaborative manner.  Those who do not abide by this Code of Conduct will not be permitted to remain part of our community.
+
+
+## Summary of Key Principles
+
+- Be respectful to others in the community at all times.
+- Report harassing or abusive behavior that you experience or witness at ReportAbuse@cyberark.com
+- The CyberArk community will not tolerate abusive or disrespectful behavior towards its members; anyone engaging in such behavior will be suspended from the CyberArk community.
+
+
+## Scope
+
+This Code of Conduct applies to all members of the CyberArk community, including paid and unpaid agents, administrators, users, and customers of CyberArk.  It applies in all CyberArk community venues, online and in person, including CyberArk Open Source project communities (such as public GitHub repositories, chat channels, social media, mailing lists, and public events) and in one-on-one communications pertaining to CyberArk affairs.
+This policy covers the usage of CyberArk hosted services, as well as the CyberArk website, CyberArk related events, and any other services offered by or on behalf of CyberArk (collectively, the "Service"). 
+This Code of Conduct is in addition to, and does not in any way nullify or invalidate, any other terms or conditions related to use of the Service.
+
+
+## Maintaining a Friendly, Harassment-Free Space
+
+We are committed to providing a friendly, safe and welcoming environment for all, regardless of gender identity, sexual orientation, ability, ethnicity, religion, age, physical appearance, body size, race, or similar personal characteristics.
+We ask that you please respect that people have differences of opinion regarding technical choices, and that every design or implementation choice carries a trade-off and numerous costs. There is seldom a single right answer. A difference of technology preferences is not a license to be rude.
+Harassing other users of the Service for any reason is never tolerated, whether via public or private media. Any spamming, trolling, flaming, baiting, or other attention-stealing behavior is not welcome, and will not be tolerated.
+Even if your intent is not to harass or offend others, be mindful of how your comments might be perceived by others in the community.
+
+
+## Unacceptable Behavior
+
+The following behaviors are considered harassment under this Code of Conduct and are unacceptable within our community:
+- Violence, threats of violence, or violent language directed against another person or group of people.
+- Sexist, racist, homophobic, transphobic, ableist, or otherwise discriminatory jokes and language.
+- Posting or displaying sexually explicit or violent material.
+- Posting or threatening to post other people’s personally identifying information ("doxing").
+- Personal insults, particularly those related to related to gender identity, sexual orientation, ability, ethnicity, religion, age, physical appearance, body size, race, or similar personal characteristics.
+- Using offensive or harassing nicknames or other identifiers.
+- Inappropriate photography or recording.
+- Inappropriate physical contact. You should have someone’s consent before touching them.
+- Unwelcome sexual attention. This includes: sexualized comments or jokes; inappropriate touching, groping, and unwelcome sexual advances.
+- Deliberate intimidation, stalking, or following (online or in person).
+- Sustained disruption of community events, including talks and presentations.
+- Advocating for, or encouraging, any of the above behavior.
+
+## Reporting Violations 
+
+If you witness or experience unacceptable behavior in the CyberArk community, please promptly report it to our team at ReportAbuse@cyberark.com.  If this is the initial report of a problem, please include as much detail as possible. It is easiest for us to address issues when we have more context.
+The CyberArk Community Team will look into any reported issues in a confidential manner and take any necessary actions to address and resolve the problem.
+We will not tolerate any form of retaliation towards users who report these issues to us.
+If you feel that you have been falsely or unfairly accused of violating this Code of Conduct by others in the community, you should notify the ReportAbuse@cyberark.com team so that we can address and resolve the accusation.
+As always, if you have an urgent security issue, contact product_security@cyberark.com and if you have concerns about a potential copyright violation, contact legal@cyberark.com.
+
+## Consequences
+
+All content published to the Service, including user account credentials, is hosted at the sole discretion of the CyberArk administrators.  If a community member engages in unacceptable behavior, the CyberArk administrators may take any action they deem appropriate, up to and including a temporary ban or permanent expulsion from the community without warning. In general, we will choose the course of action that we judge as being most in the interest of fostering a safe and friendly community.
+
+## Contact Info
+Please contact ReportAbuse@cyberark.com if you need to report a problem or address a grievance related to an abuse report.
+You are also encouraged to contact us if you have questions about what constitutes appropriate and inappropriate content. We are happy to provide guidance to help you be a successful part of our community. Our technical community is available [here](https://cyberark-customers.force.com/s/).
+
+## Credit and License
+
+This Code of Conduct borrows from the [npm Code of Conduct](https://www.npmjs.com/policies/conduct), Stumptown Syndicate [Citizen's Code of Conduct](http://citizencodeofconduct.org/), and the [Rust Project Code of Conduct](https://www.rust-lang.org/conduct.html).
+This document may be reused under a [Creative Commons Attribution-ShareAlike License](https://creativecommons.org/licenses/by-sa/4.0/).
+
+


### PR DESCRIPTION
I'm inclined to just use CyberArk's Code of Conduct as it stands. The reality of it is that we are a part of CyberArk, and although it might be a little confusing for consumers, for ancilliary files like this, it's probably better just to keep them as-is, rather than maintain sets of email aliases.