### PR TITLE
fix: Improve updates and deletion of tlspc_firefly_subca resources

### DIFF
--- a/internal/provider/firefly_subca_resource.go
+++ b/internal/provider/firefly_subca_resource.go
@@ -223,11 +223,11 @@ func (r *fireflySubCAResource) Delete(ctx context.Context, req resource.DeleteRe
 		return
 	}
 
-	err := r.client.DeleteFireflyConfig(state.ID.ValueString())
+	err := r.client.DeleteFireflySubCAProvider(state.ID.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError(
-			"Error Deleting FireflyConfig",
-			"Could not delete FireflyConfig ID "+state.ID.ValueString()+": "+err.Error(),
+			"Error Deleting Firefly SubCA Provider",
+			"Could not delete Firefly SubCA Provider ID: "+state.ID.ValueString()+": "+err.Error(),
 		)
 		return
 	}

--- a/internal/tlspc/tlspc.go
+++ b/internal/tlspc/tlspc.go
@@ -1011,8 +1011,8 @@ func (c *Client) DeleteFireflyConfig(id string) error {
 type FireflySubCAProvider struct {
 	ID                string `json:"id,omitempty"`
 	Name              string `json:"name"`
-	CAType            string `json:"caType"`
-	CAAccountID       string `json:"caAccountId"`
+	CAType            string `json:"caType,omitempty"`
+	CAAccountID       string `json:"caAccountId,omitempty"`
 	CAProductOptionID string `json:"caProductOptionId"`
 	CommonName        string `json:"commonName"`
 	KeyAlgorithm      string `json:"keyAlgorithm"`
@@ -1078,6 +1078,8 @@ func (c *Client) UpdateFireflySubCAProvider(ff FireflySubCAProvider) (*FireflySu
 		return nil, errors.New("Empty ID")
 	}
 	ff.ID = ""
+	ff.CAType = ""
+	ff.CAAccountID = ""
 	path := c.Path(`%s/v1/distributedissuers/subcaproviders/` + id)
 
 	body, err := json.Marshal(ff)


### PR DESCRIPTION
[bc12d88](https://github.com/jetstack/terraform-provider-tlspc/pull/74/commits/bc12d8865fc3c4c8c1217d7e58ddc11f2a887ec7) - this removes two fields that are used [on creation](https://developer.venafi.com/tlsprotectcloud/reference/subcaproviders_create) but are currently not present on the [update of a firefly_subca](https://developer.venafi.com/tlsprotectcloud/reference/subcaproviders_update) resource: [ "caAccountId", "caType" ]

[dba8612](https://github.com/jetstack/terraform-provider-tlspc/pull/74/commits/dba8612703faf25b21f8f1a5d08454fdb7427221) - Fixes an error where deletion was calling a FireflyConfig deletion, rather than the subca deletion. For example, it resolves errors like this one:

```
╷
│ Error: Error Deleting FireflyConfig
│
│ Could not delete FireflyConfig ID 79e2a650-407a-11f0-9118-efcd5e2fb2e6: Failed to delete Firefly Config; response was: {"errors":[{"code":10051,"message":"Unable to find venafiCaIssuerConfiguration for key
│ 79e2a650-407a-11f0-9118-efcd5e2fb2e6","args":["venafiCaIssuerConfiguration","79e2a650-407a-11f0-9118-efcd5e2fb2e6"]}]}
╵
```