### PR TITLE
Add credential_expiry attrs to *_account resources

### DIFF
--- a/docs/resources/registry_account.md
+++ b/docs/resources/registry_account.md
@@ -42,6 +42,7 @@ output "dockerconfig" {
 
 ### Read-Only
 
+- `credential_expiry` (String) Credential expiry datetime
 - `id` (String) The ID of this resource.
 - `oci_account_name` (String) Generated OCI account name
 - `oci_registry_token` (String, Sensitive) Generated OCI registry token

--- a/docs/resources/service_account.md
+++ b/docs/resources/service_account.md
@@ -72,4 +72,5 @@ resource "tlspc_service_account" "wif-issuer" {
 
 ### Read-Only
 
+- `credential_expiry` (String) Credential expiry datetime
 - `id` (String) The ID of this resource

--- a/internal/provider/registry_account_resource.go
+++ b/internal/provider/registry_account_resource.go
@@ -6,6 +6,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"terraform-provider-tlspc/internal/tlspc"
 
@@ -76,6 +77,10 @@ func (r *registryAccountResource) Schema(_ context.Context, _ resource.SchemaReq
 				Required:            true,
 				MarkdownDescription: "Credential Lifetime in days",
 			},
+			"credential_expiry": schema.StringAttribute{
+				Computed:            true,
+				MarkdownDescription: "Credential expiry datetime",
+			},
 		},
 	}
 }
@@ -107,6 +112,7 @@ type registryAccountResourceModel struct {
 	OciAccountName     types.String   `tfsdk:"oci_account_name"`
 	OciRegistryToken   types.String   `tfsdk:"oci_registry_token"`
 	CredentialLifetime types.Int32    `tfsdk:"credential_lifetime"`
+	CredentialExpiry   types.String   `tfsdk:"credential_expiry"`
 }
 
 func (r *registryAccountResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
@@ -165,6 +171,7 @@ func (r *registryAccountResource) Read(ctx context.Context, req resource.ReadReq
 	state.ID = types.StringValue(sa.ID)
 	state.Name = types.StringValue(sa.Name)
 	state.Owner = types.StringValue(sa.Owner)
+	state.CredentialExpiry = types.StringValue(sa.CredentialExpiry.Format(time.RFC3339))
 
 	scopes := []types.String{}
 	for _, v := range sa.Scopes {

--- a/internal/provider/service_account_resource.go
+++ b/internal/provider/service_account_resource.go
@@ -6,6 +6,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"terraform-provider-tlspc/internal/tlspc"
 
@@ -61,6 +62,10 @@ A list of scopes that this service account is authorised for. Available options 
     * certificate-issuance
     * kubernetes-discovery
 `,
+			},
+			"credential_expiry": schema.StringAttribute{
+				Computed:            true,
+				MarkdownDescription: "Credential expiry datetime",
 			},
 			// Agent service account
 			"public_key": schema.StringAttribute{
@@ -128,6 +133,7 @@ type serviceAccountResourceModel struct {
 	Audience           types.String   `tfsdk:"audience"`
 	Subject            types.String   `tfsdk:"subject"`
 	Applications       []types.String `tfsdk:"applications"`
+	CredentialExpiry   types.String   `tfsdk:"credential_expiry"`
 }
 
 func (r *serviceAccountResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
@@ -221,6 +227,7 @@ func (r *serviceAccountResource) Read(ctx context.Context, req resource.ReadRequ
 	state.ID = types.StringValue(sa.ID)
 	state.Name = types.StringValue(sa.Name)
 	state.Owner = types.StringValue(sa.Owner)
+	state.CredentialExpiry = types.StringValue(sa.CredentialExpiry.Format(time.RFC3339))
 	if sa.PublicKey != state.PublicKey.ValueString() {
 		state.PublicKey = types.StringValue(sa.PublicKey)
 	}

--- a/internal/tlspc/tlspc.go
+++ b/internal/tlspc/tlspc.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"time"
 )
 
 const DefaultEndpoint = "https://api.venafi.cloud"
@@ -303,20 +304,21 @@ func (c *Client) DeleteTeam(id string) error {
 }
 
 type ServiceAccount struct {
-	ID                 string   `json:"id,omitempty"`
-	Name               string   `json:"name"`
-	Owner              string   `json:"owner"`
-	Scopes             []string `json:"scopes"`
-	CredentialLifetime int32    `json:"credentialLifetime,omitempty"`
-	PublicKey          string   `json:"publicKey,omitempty"`
-	AuthenticationType string   `json:"authenticationType,omitempty"`
-	OciAccountName     string   `json:"ociAccountName,omitempty"`
-	OciRegistryToken   string   `json:"ociRegistryToken,omitempty"`
-	JwksURI            string   `json:"jwksURI,omitempty"`
-	IssuerURL          string   `json:"issuerURL,omitempty"`
-	Audience           string   `json:"audience,omitempty"`
-	Subject            string   `json:"subject,omitempty"`
-	Applications       []string `json:"applications,omitempty"`
+	ID                 string    `json:"id,omitempty"`
+	Name               string    `json:"name"`
+	Owner              string    `json:"owner"`
+	Scopes             []string  `json:"scopes"`
+	CredentialLifetime int32     `json:"credentialLifetime,omitempty"`
+	CredentialExpiry   time.Time `json:"credentialsExpiringOn,omitempty"`
+	PublicKey          string    `json:"publicKey,omitempty"`
+	AuthenticationType string    `json:"authenticationType,omitempty"`
+	OciAccountName     string    `json:"ociAccountName,omitempty"`
+	OciRegistryToken   string    `json:"ociRegistryToken,omitempty"`
+	JwksURI            string    `json:"jwksURI,omitempty"`
+	IssuerURL          string    `json:"issuerURL,omitempty"`
+	Audience           string    `json:"audience,omitempty"`
+	Subject            string    `json:"subject,omitempty"`
+	Applications       []string  `json:"applications,omitempty"`
 }
 
 func (c *Client) CreateServiceAccount(sa ServiceAccount) (*ServiceAccount, error) {


### PR DESCRIPTION
Add credential_expiry attributes in order to provide users with more control of how/when to rotate credentials/accounts.

Vaguely inspired by #91