### PR TITLE
fix: Handle cases where user email has been reused

### DIFF
--- a/internal/tlspc/tlspc.go
+++ b/internal/tlspc/tlspc.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 )
 
 const DefaultEndpoint = "https://api.venafi.cloud"
@@ -79,7 +80,16 @@ type Users struct {
 }
 
 func (c *Client) GetUser(email string) (*User, error) {
-	path := c.Path(`%s/v1/users/username/` + email)
+	// Return a single user based on email matching.
+	// Ignore deleted users which the API will return.
+	// Disabled users are returned but other API calls will error this state.
+	// Refer to https://developer.venafi.com/tlsprotectcloud/reference/get-v1-users for details of the API behaviour.
+	path := c.Path(`%s/v1/users`)
+
+	queryParams := url.Values{}
+	queryParams.Set("deleted", "false")
+	queryParams.Set("username", email)
+	path = path + "?" + queryParams.Encode()
 
 	resp, err := c.Get(path)
 	if err != nil {


### PR DESCRIPTION
Fixes #103.

The API returns all users for a given email addressed through all history. This means deleted users are returned. We do not care about old deleted users. New users with the same email will have a new UUID. We can use the fact this changes to highlight there may be something to look at. Most likely this fixes my unique issue but I could see it being a problem in longer lived tenants as people may leave and rejoin. Especially as there is no ability to modify user details like name after creation.

## Testing

I tested this with my broken tenant, with both and email that returns 1 user, and an email that returns 2 users:

```sh
➜  tofu plan -var-file=inputs.tfvars -refresh -out plan
╷
│ Warning: Provider development overrides are in effect
│
│ The following provider development overrides are set in the CLI configuration:
│  - jetstack/tlspc in /Users/peter.fiddes/projects/jetstack/terraform-provider-tlspc
│
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become
│ incompatible with published releases.
╵
data.tlspc_user.admin: Reading...
data.tlspc_user.platform: Reading...
data.tlspc_user.admin: Read complete after 1s [id=2c0a67c0-13af-11f1-b2e2-91c6a0bc61cc]
data.tlspc_user.platform: Read complete after 1s [id=f6e90d00-13b6-11f1-a0a8-5b906cf2270f]

No changes. Your infrastructure matches the configuration.

OpenTofu has compared your real infrastructure against your configuration and found no differences, so no changes are needed.


➜ tofu apply plan
╷
│ Warning: Provider development overrides are in effect
│
│ The following provider development overrides are set in the CLI configuration:
│  - jetstack/tlspc in /Users/peter.fiddes/projects/jetstack/terraform-provider-tlspc
│
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become
│ incompatible with published releases.
╵

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
```

Importantly the ID returned matches the correct active / not delete user:

```sh
curl -s --request GET \
     --url https://api.au.venafi.cloud/v1/users \
     --header 'accept: application/json' \
     --header 'content-type: application/json' \
     --header "tppl-api-key: $TF_VAR_vcp_api_key" | jq '.users[].id'

"e1571200-dfb1-11ef-9125-8dbc0cd36e8e"
"f6e90d00-13b6-11f1-a0a8-5b906cf2270f"
"2c0a67c0-13af-11f1-b2e2-91c6a0bc61cc"
```