### PR TITLE
chore: Update golangci-lint configuration using migrate command

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,10 +29,10 @@ jobs:
           cache: true
       - run: go mod download
       - run: go build -v .
-      - name: Run linters
-        uses: golangci/golangci-lint-action@971e284b6050e8a5849b72094c50ab08da042db8 # v6.1.1
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
-          version: latest
+          version: v2.10
 
   generate:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ website/node_modules
 *.iml
 *.test
 *.iml
+.golangci.bck.yml
 
 website/vendor
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,27 +1,44 @@
-# Visit https://golangci-lint.run/ for usage documentation
-# and information on other useful linters
-issues:
-  max-per-linter: 0
-  max-same-issues: 0
-
+version: "2"
 linters:
-  disable-all: true
+  default: none
   enable:
+    - copyloopvar
     - durationcheck
     - errcheck
-    - copyloopvar
     - forcetypeassert
     - godot
-    - gofmt
-    - gosimple
+    - govet
     - ineffassign
     - makezero
     - misspell
     - nilerr
     - predeclared
     - staticcheck
-    - tenv
     - unconvert
     - unparam
     - unused
-    - govet
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+  settings:
+    staticcheck:
+      checks: ["all", "-SA9003", "-ST1000", "-ST1003", "-ST1016", "-ST1020", "-ST1021", "-ST1022", "-ST1023", "-ST1005"]
+issues:
+  max-same-issues: 0
+formatters:
+  enable:
+    - gofmt
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/internal/tlspc/graphql.go
+++ b/internal/tlspc/graphql.go
@@ -18,7 +18,7 @@ func (c *Client) GetGraphQLClient() gql.Client {
 	httpClient := http.DefaultClient
 	rt := WithHeader(httpClient.Transport)
 	rt.Set("tppl-api-key", c.apikey)
-	rt.Header.Set("User-Agent", "terraform-provider-tlspc/"+c.version)
+	rt.Set("User-Agent", "terraform-provider-tlspc/"+c.version)
 	httpClient.Transport = rt
 
 	path := c.Path(`%s/graphql`)


### PR DESCRIPTION
I was unable to run the linter locally due to having a newer version of golangci-lint. It suggested migrating using: `golangci-lint migrate`. I've since applied some very minimal configuration to ensure lint runs as before. That means ignoreing 49 issues of ST1005 and fixing one QF1008.

I figure we should get this updates, then separately have PRs to fix things we want to fix, whilst CI is not broken.