### PR TITLE
feat: Add key_algorithm configuration to application template

### DIFF
--- a/docs/data-sources/certificate_template.md
+++ b/docs/data-sources/certificate_template.md
@@ -31,4 +31,5 @@ data "tlspc_certificate_template" "default" {
 
 - `ca_product_id` (String) The ID of a Certificate Authority Product Option
 - `id` (String) The ID of this resource.
+- `key_algorithms` (List of String) Allowed key algorithms
 - `key_reuse` (Boolean) Allow Private Key Reuse

--- a/docs/resources/certificate_template.md
+++ b/docs/resources/certificate_template.md
@@ -31,8 +31,20 @@ resource "tlspc_certificate_template" "built_in" {
 
 - `ca_product_id` (String) The ID of a Certificate Authority Product Option
 - `ca_type` (String) Type of Certificate Authority (see Certificate Authority Product Option data source)
-- `key_reuse` (Boolean) Allow Private Key Reuse
 - `name` (String) Name of the Certificate Issuing Template
+
+### Optional
+
+- `key_algorithms` (List of String) Key Algorithm. Valid options include:
+	* RSA_1024
+	* RSA_2048
+	* RSA_3072
+	* RSA_4096
+	* EC_P256
+	* EC_P384
+	* EC_P521
+	* EC_ED25519
+- `key_reuse` (Boolean) Allow Private Key Reuse, defaults to false
 
 ### Read-Only
 

--- a/docs/resources/certificate_template.md
+++ b/docs/resources/certificate_template.md
@@ -44,6 +44,7 @@ resource "tlspc_certificate_template" "built_in" {
 	* EC_P384
 	* EC_P521
 	* EC_ED25519
+	If unspecified, defaults to: [RSA_2048, RSA_3072, RSA_4096],
 - `key_reuse` (Boolean) Allow Private Key Reuse, defaults to false
 
 ### Read-Only

--- a/internal/provider/certificate_template_data_source.go
+++ b/internal/provider/certificate_template_data_source.go
@@ -80,16 +80,22 @@ func (d *certTemplateDataSource) Schema(_ context.Context, _ datasource.SchemaRe
 				Computed:            true,
 				MarkdownDescription: "Allow Private Key Reuse",
 			},
+			"key_algorithms": schema.ListAttribute{
+				Computed:            true,
+				ElementType:         types.StringType,
+				MarkdownDescription: "Allowed key algorithms",
+			},
 		},
 	}
 }
 
 type certTemplateDataSourceModel struct {
-	ID          types.String `tfsdk:"id"`
-	Name        types.String `tfsdk:"name"`
-	CAType      types.String `tfsdk:"ca_type"`
-	CAProductID types.String `tfsdk:"ca_product_id"`
-	KeyReuse    types.Bool   `tfsdk:"key_reuse"`
+	ID            types.String   `tfsdk:"id"`
+	Name          types.String   `tfsdk:"name"`
+	CAType        types.String   `tfsdk:"ca_type"`
+	CAProductID   types.String   `tfsdk:"ca_product_id"`
+	KeyReuse      types.Bool     `tfsdk:"key_reuse"`
+	KeyAlgorithms []types.String `tfsdk:"key_algorithms"`
 }
 
 // Read refreshes the Terraform state with the latest data.
@@ -116,6 +122,7 @@ func (d *certTemplateDataSource) Read(ctx context.Context, req datasource.ReadRe
 			model.ID = types.StringValue(v.ID)
 			model.CAProductID = types.StringValue(v.CertificateAuthorityProductOptionID)
 			model.KeyReuse = types.BoolValue(v.KeyReuse)
+			model.KeyAlgorithms = keyAlgorithmsFromKeyTypes(v.KeyTypes)
 			found = true
 			continue
 		}

--- a/internal/provider/certificate_template_key_types.go
+++ b/internal/provider/certificate_template_key_types.go
@@ -5,7 +5,6 @@ package provider
 
 import (
 	"fmt"
-	"slices"
 	"strconv"
 	"strings"
 
@@ -14,11 +13,21 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
-var allowedKeyLengths = []int32{1024, 2048, 3072, 4096}
-var allowedKeyCurves = []string{"P256", "P384", "P521", "ED25519"}
+// Keep a short list of the only 8 options supported.
+var allowedAlgorithms = []string{
+	"RSA_1024",
+	"RSA_2048",
+	"RSA_3072",
+	"RSA_4096",
+	"EC_P256",
+	"EC_P384",
+	"EC_P521",
+	"EC_ED25519",
+}
 
 func keyTypesFromAlgorithms(in []types.String) []tlspc.KeyType {
 	// Take in a list of allowed key algorithms and return API compatible objects.
+	// Validation of input is performed at the schema by tfsdk so all inputs can be assumed to be valid.
 	out := make([]tlspc.KeyType, 0, len(in))
 
 	klength := []int32{}
@@ -26,33 +35,13 @@ func keyTypesFromAlgorithms(in []types.String) []tlspc.KeyType {
 
 	for _, v := range in {
 		prts := strings.Split(v.ValueString(), "_")
-
-		// First check no unknown key types or malformed input.
-		if prts[0] != "RSA" && prts[0] != "EC" || len(prts) != 2 {
-			fmt.Printf("Invalid key algorithm: %s\n", v.ValueString())
-			continue
-		}
-
 		// If RSA convert the length part to int32 and add to list.
 		if prts[0] == "RSA" {
-			length, err := strconv.Atoi(prts[1])
-			if err != nil {
-				fmt.Printf("Invalid key length in algorithm: %s\n", prts[1])
-				continue
-			}
-			if !slices.Contains(allowedKeyLengths, int32(length)) {
-				fmt.Printf("Unsupported key length: %d\n", length)
-				continue
-			}
+			length, _ := strconv.Atoi(prts[1])
 			klength = append(klength, int32(length))
 		}
-
 		// If EC check curve is known and add to list.
 		if prts[0] == "EC" {
-			if !slices.Contains(allowedKeyCurves, prts[1]) {
-				fmt.Printf("Unsupported key curve: %s\n", prts[1])
-				continue
-			}
 			kcurves = append(kcurves, prts[1])
 		}
 	}

--- a/internal/provider/certificate_template_key_types.go
+++ b/internal/provider/certificate_template_key_types.go
@@ -13,18 +13,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
-// Keep a short list of the only 8 options supported.
-var allowedAlgorithms = []string{
-	"RSA_1024",
-	"RSA_2048",
-	"RSA_3072",
-	"RSA_4096",
-	"EC_P256",
-	"EC_P384",
-	"EC_P521",
-	"EC_ED25519",
-}
-
 func keyTypesFromAlgorithms(in []types.String) []tlspc.KeyType {
 	// Take in a list of allowed key algorithms and return API compatible objects.
 	// Validation of input is performed at the schema by tfsdk so all inputs can be assumed to be valid.

--- a/internal/provider/certificate_template_key_types.go
+++ b/internal/provider/certificate_template_key_types.go
@@ -1,0 +1,99 @@
+// Copyright (c) Venafi, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package provider
+
+import (
+	"fmt"
+	"slices"
+	"strconv"
+	"strings"
+
+	"terraform-provider-tlspc/internal/tlspc"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+var allowedKeyLengths = []int32{1024, 2048, 3072, 4096}
+var allowedKeyCurves = []string{"P256", "P384", "P521", "ED25519"}
+
+func keyTypesFromAlgorithms(in []types.String) []tlspc.KeyType {
+	// Take in a list of allowed key algorithms and return API compatible objects.
+	out := make([]tlspc.KeyType, 0, len(in))
+
+	klength := []int32{}
+	kcurves := []string{}
+
+	for _, v := range in {
+		prts := strings.Split(v.ValueString(), "_")
+
+		// First check no unknown key types or malformed input.
+		if prts[0] != "RSA" && prts[0] != "EC" || len(prts) != 2 {
+			fmt.Printf("Invalid key algorithm: %s\n", v.ValueString())
+			continue
+		}
+
+		// If RSA convert the length part to int32 and add to list.
+		if prts[0] == "RSA" {
+			length, err := strconv.Atoi(prts[1])
+			if err != nil {
+				fmt.Printf("Invalid key length in algorithm: %s\n", prts[1])
+				continue
+			}
+			if !slices.Contains(allowedKeyLengths, int32(length)) {
+				fmt.Printf("Unsupported key length: %d\n", length)
+				continue
+			}
+			klength = append(klength, int32(length))
+		}
+
+		// If EC check curve is known and add to list.
+		if prts[0] == "EC" {
+			if !slices.Contains(allowedKeyCurves, prts[1]) {
+				fmt.Printf("Unsupported key curve: %s\n", prts[1])
+				continue
+			}
+			kcurves = append(kcurves, prts[1])
+		}
+	}
+
+	// If we have any RSA inputs, output correct API object.
+	if len(klength) > 0 {
+		obj := tlspc.KeyType{
+			Type:       "RSA",
+			KeyLengths: klength,
+		}
+		out = append(out, obj)
+	}
+
+	// If we have any EC inputs, output correct API object.
+	if len(kcurves) > 0 {
+		obj := tlspc.KeyType{
+			Type:      "EC",
+			KeyCurves: kcurves,
+		}
+		out = append(out, obj)
+	}
+
+	return out
+}
+
+func keyAlgorithmsFromKeyTypes(in []tlspc.KeyType) []types.String {
+	// Take in a list of API key type objects and return a list of allowed key algorithms.
+	out := []types.String{}
+
+	for _, v := range in {
+		if v.Type == "RSA" {
+			for _, l := range v.KeyLengths {
+				out = append(out, types.StringValue(fmt.Sprintf("RSA_%d", l)))
+			}
+		}
+		if v.Type == "EC" {
+			for _, c := range v.KeyCurves {
+				out = append(out, types.StringValue(fmt.Sprintf("EC_%s", c)))
+			}
+		}
+	}
+
+	return out
+}

--- a/internal/provider/certificate_template_resource.go
+++ b/internal/provider/certificate_template_resource.go
@@ -9,9 +9,12 @@ import (
 
 	"terraform-provider-tlspc/internal/tlspc"
 
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -21,6 +24,15 @@ var (
 	_ resource.Resource                = &certificateTemplateResource{}
 	_ resource.ResourceWithConfigure   = &certificateTemplateResource{}
 	_ resource.ResourceWithImportState = &certificateTemplateResource{}
+)
+
+var defaultKeyAlgorithms = types.ListValueMust(
+	types.StringType,
+	[]attr.Value{
+		types.StringValue("RSA_2048"),
+		types.StringValue("RSA_3072"),
+		types.StringValue("RSA_4096"),
+	},
 )
 
 type certificateTemplateResource struct {
@@ -60,15 +72,27 @@ func (r *certificateTemplateResource) Schema(_ context.Context, _ resource.Schem
 				MarkdownDescription: "The ID of a Certificate Authority Product Option",
 			},
 			"key_reuse": schema.BoolAttribute{
-				Required:            true,
-				MarkdownDescription: "Allow Private Key Reuse",
+				Optional:            true,
+				Computed:            true,
+				Default:             booldefault.StaticBool(false),
+				MarkdownDescription: "Allow Private Key Reuse, defaults to false",
 			},
-			/*
-				"key_types": schema.SetAttribute{
-					Required:    true,
-					ElementType: types.MapType,
-				},
-			*/
+			"key_algorithms": schema.ListAttribute{
+				Optional:    true,
+				Computed:    true,
+				ElementType: types.StringType,
+				Default:     listdefault.StaticValue(defaultKeyAlgorithms),
+				MarkdownDescription: `Key Algorithm. Valid options include:
+	* RSA_1024
+	* RSA_2048
+	* RSA_3072
+	* RSA_4096
+	* EC_P256
+	* EC_P384
+	* EC_P521
+	* EC_ED25519
+`,
+			},
 		},
 	}
 }
@@ -93,12 +117,12 @@ func (r *certificateTemplateResource) Configure(_ context.Context, req resource.
 }
 
 type certificateTemplateResourceModel struct {
-	ID          types.String `tfsdk:"id"`
-	Name        types.String `tfsdk:"name"`
-	CAType      types.String `tfsdk:"ca_type"`
-	CAProductID types.String `tfsdk:"ca_product_id"`
-	KeyReuse    types.Bool   `tfsdk:"key_reuse"`
-	//KeyTypes    []types.Map  `tfsdk:"key_types"`
+	ID            types.String   `tfsdk:"id"`
+	Name          types.String   `tfsdk:"name"`
+	CAType        types.String   `tfsdk:"ca_type"`
+	CAProductID   types.String   `tfsdk:"ca_product_id"`
+	KeyReuse      types.Bool     `tfsdk:"key_reuse"`
+	KeyAlgorithms []types.String `tfsdk:"key_algorithms"`
 }
 
 func (r *certificateTemplateResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
@@ -124,19 +148,14 @@ func (r *certificateTemplateResource) Create(ctx context.Context, req resource.C
 		CertificateAuthorityProductOptionID: plan.CAProductID.ValueString(),
 		Product:                             pt.Details.Template,
 		KeyReuse:                            plan.KeyReuse.ValueBool(),
-		KeyTypes: []tlspc.KeyType{
-			{
-				Type:       "RSA",
-				KeyLengths: []int32{2048, 3072, 4096},
-			},
-		},
-		SANRegexes:       []string{".*"},
-		SubjectCNRegexes: []string{".*"},
-		SubjectCValues:   []string{".*"},
-		SubjectLRegexes:  []string{".*"},
-		SubjectORegexes:  []string{".*"},
-		SubjectOURegexes: []string{".*"},
-		SubjectSTRegexes: []string{".*"},
+		KeyTypes:                            keyTypesFromAlgorithms(plan.KeyAlgorithms),
+		SANRegexes:                          []string{".*"},
+		SubjectCNRegexes:                    []string{".*"},
+		SubjectCValues:                      []string{".*"},
+		SubjectLRegexes:                     []string{".*"},
+		SubjectORegexes:                     []string{".*"},
+		SubjectOURegexes:                    []string{".*"},
+		SubjectSTRegexes:                    []string{".*"},
 	}
 
 	created, err := r.client.CreateCertificateTemplate(ct)
@@ -174,6 +193,7 @@ func (r *certificateTemplateResource) Read(ctx context.Context, req resource.Rea
 	state.CAType = types.StringValue(ct.CertificateAuthorityType)
 	state.CAProductID = types.StringValue(ct.CertificateAuthorityProductOptionID)
 	state.KeyReuse = types.BoolValue(ct.KeyReuse)
+	state.KeyAlgorithms = keyAlgorithmsFromKeyTypes(ct.KeyTypes)
 
 	diags = resp.State.Set(ctx, state)
 	resp.Diagnostics.Append(diags...)
@@ -209,19 +229,14 @@ func (r *certificateTemplateResource) Update(ctx context.Context, req resource.U
 		CertificateAuthorityProductOptionID: plan.CAProductID.ValueString(),
 		Product:                             pt.Details.Template,
 		KeyReuse:                            plan.KeyReuse.ValueBool(),
-		KeyTypes: []tlspc.KeyType{
-			{
-				Type:       "RSA",
-				KeyLengths: []int32{2048, 3072, 4096},
-			},
-		},
-		SANRegexes:       []string{".*"},
-		SubjectCNRegexes: []string{".*"},
-		SubjectCValues:   []string{".*"},
-		SubjectLRegexes:  []string{".*"},
-		SubjectORegexes:  []string{".*"},
-		SubjectOURegexes: []string{".*"},
-		SubjectSTRegexes: []string{".*"},
+		KeyTypes:                            keyTypesFromAlgorithms(plan.KeyAlgorithms),
+		SANRegexes:                          []string{".*"},
+		SubjectCNRegexes:                    []string{".*"},
+		SubjectCValues:                      []string{".*"},
+		SubjectLRegexes:                     []string{".*"},
+		SubjectORegexes:                     []string{".*"},
+		SubjectOURegexes:                    []string{".*"},
+		SubjectSTRegexes:                    []string{".*"},
 	}
 
 	updated, err := r.client.UpdateCertificateTemplate(ct)

--- a/internal/provider/certificate_template_resource.go
+++ b/internal/provider/certificate_template_resource.go
@@ -9,6 +9,8 @@ import (
 
 	"terraform-provider-tlspc/internal/tlspc"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -17,6 +19,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -82,6 +85,11 @@ func (r *certificateTemplateResource) Schema(_ context.Context, _ resource.Schem
 				Computed:    true,
 				ElementType: types.StringType,
 				Default:     listdefault.StaticValue(defaultKeyAlgorithms),
+				Validators: []validator.List{
+					listvalidator.ValueStringsAre(
+						stringvalidator.OneOf(allowedAlgorithms...),
+					),
+				},
 				MarkdownDescription: `Key Algorithm. Valid options include:
 	* RSA_1024
 	* RSA_2048
@@ -91,6 +99,7 @@ func (r *certificateTemplateResource) Schema(_ context.Context, _ resource.Schem
 	* EC_P384
 	* EC_P521
 	* EC_ED25519
+	If unspecified, defaults to: [RSA_2048, RSA_3072, RSA_4096],
 `,
 			},
 		},

--- a/internal/provider/certificate_template_resource.go
+++ b/internal/provider/certificate_template_resource.go
@@ -87,7 +87,9 @@ func (r *certificateTemplateResource) Schema(_ context.Context, _ resource.Schem
 				Default:     listdefault.StaticValue(defaultKeyAlgorithms),
 				Validators: []validator.List{
 					listvalidator.ValueStringsAre(
-						stringvalidator.OneOf(allowedAlgorithms...),
+						stringvalidator.OneOf(
+							"RSA_1024", "RSA_2048", "RSA_3072", "RSA_4096", "EC_P256", "EC_P384", "EC_P521", "EC_ED25519",
+						),
 					),
 				},
 				MarkdownDescription: `Key Algorithm. Valid options include:


### PR DESCRIPTION
Partially fixes #33.

The key algorithm and relevant parameters were hard coded. This change allows you to specify options you would like in a succinct manner. It also defaults the values if unspecified in order to minimise configuration. key_reuse option also now defaults to false for more minimal configuration.

Example testing resource:

```hcl
resource "tlspc_certificate_template" "provider_test" {
  name          = "provider-test-template"
  ca_type       = data.tlspc_ca_product.built_in.type
  ca_product_id = data.tlspc_ca_product.built_in.id
  # key_reuse     = true
  # key_algorithms = ["RSA_1024", "RSA_2048", "RSA_3072", "RSA_4096", "EC_P256", "EC_P384", "EC_P521", "EC_ED25519"]
  key_algorithms = ["RSA_3072", "RSA_4096", "EC_ED25519"]
}
```

Result:

<img width="770" height="140" alt="Screenshot 2026-03-18 at 14 55 42" src="https://github.com/user-attachments/assets/a01bedd1-4978-4b87-ade3-c27523a7771c" />

State:

```sh
# tlspc_certificate_template.provider_test:
resource "tlspc_certificate_template" "provider_test" {
    ca_product_id  = "47678210-f64b-11ee-a73e-d7aec1cfe39b"
    ca_type        = "BUILTIN"
    id             = "50086510-220e-11f1-9dc7-ab147436f184"
    key_algorithms = [
        "RSA_3072",
        "RSA_4096",
        "EC_ED25519",
    ]
    key_reuse      = false
    name           = "provider-test-template"
}
```
